### PR TITLE
Move to Linaro Buster based release

### DIFF
--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/build_scripts/build_linux.sh
+++ b/build_scripts/build_linux.sh
@@ -11,16 +11,16 @@ sudo apt install android-tools-fsutils
 sudo apt install qemu-user-static
 
 # Converting from Android sparse format to raw format
-gunzip linaro-stretch-developer-qcom-snapdragon-arm64-20171016-283.img.gz 
-simg2img linaro-stretch-developer-qcom-snapdragon-arm64-20171016-283.img linaro-stretch-developer-qcom-snapdragon-arm64-20171016-283.img.raw
+gunzip -c linaro-buster-developer-dragonboard-410c-528.img.gz > linaro-buster-developer-dragonboard-410c-528.img
+simg2img linaro-*.img martha-linaro-developer-dragonboard-410c.img.raw
 
 # resize disk
-resize2fs linaro-stretch-developer-qcom-snapdragon-arm64-20171016-283.img.raw 3G
+e2fsck -f martha-linaro-developer-dragonboard-410c.img.raw
+resize2fs martha-linaro-developer-dragonboard-410c.img.raw 3G
 
 # mount 
 mkdir mnt-point
-sudo mount -t ext4 -o loop linaro-stretch-developer-qcom-snapdragon-arm64-20171016-283.img.raw mnt-point
-# sudo mount --bind /dev mnt-point/dev
+sudo mount -t ext4 -o loop martha-linaro-developer-dragonboard-410c.img.raw mnt-point
 sudo mount -t proc -o nosuid,noexec,nodev proc mnt-point/proc
 sudo mount -t sysfs -o nosuid,noexec,nodev sysfs mnt-point/sys
 sudo mount -t devtmpfs -o mode=0755,nosuid devtmpfs mnt-point/dev
@@ -34,7 +34,7 @@ sudo cp /usr/bin/qemu-aarch64-static mnt-point/usr/bin
 sudo chroot mnt-point apt -y update
 sudo chroot mnt-point apt -y install locales
 sudo chroot mnt-point apt -y upgrade
-sudo chroot mnt-point apt -y install build-essential autoconf libtool cmake pkg-config git python3-dev swig3.0 libpcre3-dev nodejs-dev
+sudo chroot mnt-point apt -y install build-essential autoconf libtool cmake pkg-config git python3-dev swig3.0 libpcre3-dev libnode-dev
 sudo chroot mnt-point apt -y install links2 lynx
 sudo chroot mnt-point apt -y install python3-pip
 sudo chroot mnt-point pip3 install --upgrade pip
@@ -80,10 +80,10 @@ sudo umount mnt-point/sys
 sudo umount mnt-point
 
 # Resize image
-e2fsck -f linaro-stretch-developer-qcom-snapdragon-arm64-20171016-283.img.raw
-resize2fs -M linaro-stretch-developer-qcom-snapdragon-arm64-20171016-283.img.raw
+e2fsck -f martha-linaro-developer-dragonboard-410c.img.raw
+resize2fs -M martha-linaro-developer-dragonboard-410c.img.raw
 
 # Converting from raw format to Android sparse format
-ext2simg linaro-stretch-developer-qcom-snapdragon-arm64-20171016-283.img.raw linaro-stretch-developer-qcom-snapdragon-arm64-20171016-283_martha.img
+img2simg martha-linaro-developer-dragonboard-410c.img.raw martha-linaro-developer-dragonboard-410c.img
 
 

--- a/build_scripts/build_linux.sh
+++ b/build_scripts/build_linux.sh
@@ -33,6 +33,8 @@ sudo cp /usr/bin/qemu-aarch64-static mnt-point/usr/bin
 # update system
 sudo chroot mnt-point apt -y update
 sudo chroot mnt-point apt -y install locales
+sudo sed -i 's/^# en_GB.UTF-8 UTF-8/en_GB.UTF-8 UTF-8/' mnt-point/etc/locale.gen
+sudo chroot mnt-point locale-gen 
 sudo chroot mnt-point apt -y upgrade
 sudo chroot mnt-point apt -y install build-essential autoconf libtool cmake pkg-config git python3-dev swig3.0 libpcre3-dev libnode-dev
 sudo chroot mnt-point apt -y install links2 lynx

--- a/build_scripts/build_martha_package_linux.sh
+++ b/build_scripts/build_martha_package_linux.sh
@@ -8,10 +8,10 @@ cd project_martha_linux
 echo ${PWD}
 
 unzip ../download_adb/platform-tools-latest-linux.zip
-unzip ../linux-martha/dragonboard410c_bootloader_emmc_linux-88.zip -d db_image
-cp ../linux-martha/boot-linaro-stretch-qcom-snapdragon-arm64-20171016-283.img.gz db_image
-gunzip db_image/boot-linaro-stretch-qcom-snapdragon-arm64-20171016-283.img.gz
-cp ../linux-martha/linaro-stretch-developer-qcom-snapdragon-arm64-20171016-283_martha.img db_image
+unzip ../linux-martha/dragonboard-410c-bootloader-emmc-linux-*.zip -d db_image
+cp ../linux-martha/boot-linaro-*.img.gz db_image
+gunzip db_image/boot-linaro-*.img.gz
+cp ../linux-martha/martha-linaro-developer-dragonboard-410c.img db_image
 cp ../src/flash_db410.sh .
 
 cd ..

--- a/build_scripts/build_martha_package_macos.sh
+++ b/build_scripts/build_martha_package_macos.sh
@@ -8,10 +8,10 @@ cd project_martha_macos
 echo ${PWD}
 
 unzip ../download_adb/platform-tools-latest-darwin.zip
-unzip ../linux-martha/dragonboard410c_bootloader_emmc_linux-88.zip -d db_image
-cp ../linux-martha/boot-linaro-stretch-qcom-snapdragon-arm64-20171016-283.img.gz db_image
-gunzip db_image/boot-linaro-stretch-qcom-snapdragon-arm64-20171016-283.img.gz
-cp ../linux-martha/linaro-stretch-developer-qcom-snapdragon-arm64-20171016-283_martha.img db_image
+unzip ../linux-martha/dragonboard410c_bootloader_emmc_linux-*.zip -d db_image
+cp ../linux-martha/boot-linaro-*.img.gz db_image
+gunzip db_image/boot-linaro-*.img.gz
+cp ../linux-martha/martha-linaro-developer-dragonboard-410c.img db_image
 cp ../src/flash_db410.sh flash_db410.command
 
 cd ..

--- a/build_scripts/build_martha_package_macos.sh
+++ b/build_scripts/build_martha_package_macos.sh
@@ -8,7 +8,7 @@ cd project_martha_macos
 echo ${PWD}
 
 unzip ../download_adb/platform-tools-latest-darwin.zip
-unzip ../linux-martha/dragonboard410c_bootloader_emmc_linux-*.zip -d db_image
+unzip ../linux-martha/dragonboard-410c-bootloader-emmc-linux-*.zip -d db_image
 cp ../linux-martha/boot-linaro-*.img.gz db_image
 gunzip db_image/boot-linaro-*.img.gz
 cp ../linux-martha/martha-linaro-developer-dragonboard-410c.img db_image

--- a/build_scripts/build_martha_package_windows.sh
+++ b/build_scripts/build_martha_package_windows.sh
@@ -8,7 +8,7 @@ cd project_martha_windows
 echo ${PWD}
 
 unzip ../download_adb/platform-tools-latest-windows.zip
-unzip ../linux-martha/dragonboard410c_bootloader_emmc_linux-*.zip -d db_image
+unzip ../linux-martha/dragonboard-410c-bootloader-emmc-linux-*.zip -d db_image
 cp ../linux-martha/boot-linaro-*.img.gz db_image
 gunzip db_image/boot-linaro-*.img.gz
 cp ../linux-martha/martha-linaro-developer-dragonboard-410c.img db_image

--- a/build_scripts/build_martha_package_windows.sh
+++ b/build_scripts/build_martha_package_windows.sh
@@ -8,10 +8,10 @@ cd project_martha_windows
 echo ${PWD}
 
 unzip ../download_adb/platform-tools-latest-windows.zip
-unzip ../linux-martha/dragonboard410c_bootloader_emmc_linux-88.zip -d db_image
-cp ../linux-martha/boot-linaro-stretch-qcom-snapdragon-arm64-20171016-283.img.gz db_image
-gunzip db_image/boot-linaro-stretch-qcom-snapdragon-arm64-20171016-283.img.gz
-cp ../linux-martha/linaro-stretch-developer-qcom-snapdragon-arm64-20171016-283_martha.img db_image
+unzip ../linux-martha/dragonboard410c_bootloader_emmc_linux-*.zip -d db_image
+cp ../linux-martha/boot-linaro-*.img.gz db_image
+gunzip db_image/boot-linaro-*.img.gz
+cp ../linux-martha/martha-linaro-developer-dragonboard-410c.img db_image
 cp ../src/flash_db410.cmd .
 
 cd ..

--- a/build_scripts/build_theia.sh
+++ b/build_scripts/build_theia.sh
@@ -15,7 +15,7 @@ npm install -g yarn
 
 # Install dependencies
 sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-sudo apt-get install build-essential autoconf libtool cmake pkg-config git python3-dev swig3.0 libpcre3-dev nodejs-dev
+sudo apt-get install build-essential autoconf libtool cmake pkg-config git python3-dev swig3.0 libpcre3-dev libnode-dev
 pip3 install python-language-server
 pip3 install jedi
 

--- a/build_scripts/download_linux.sh
+++ b/build_scripts/download_linux.sh
@@ -7,10 +7,10 @@ cd linux-martha
 
 # Get three files
 # boot installer
-wget https://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/17.09/dragonboard410c_bootloader_emmc_linux-88.zip
+wget http://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/19.01/dragonboard-410c-bootloader-emmc-linux-110.zip
 
 # boot image
-wget http://releases.linaro.org/96boards/dragonboard410c/linaro/debian/17.09/boot-linaro-stretch-qcom-snapdragon-arm64-20171016-283.img.gz
+wget http://releases.linaro.org/96boards/dragonboard410c/linaro/debian/19.01/boot-linaro-buster-dragonboard-410c-528.img.gz
 
 # rootfs image
-wget http://releases.linaro.org/96boards/dragonboard410c/linaro/debian/17.09/linaro-stretch-developer-qcom-snapdragon-arm64-20171016-283.img.gz
+wget http://releases.linaro.org/96boards/dragonboard410c/linaro/debian/19.01/linaro-buster-developer-dragonboard-410c-528.img.gz

--- a/src/flash_db410.cmd
+++ b/src/flash_db410.cmd
@@ -21,8 +21,8 @@ platform-tools\fastboot reboot
 
 ECHO Wait for reboot
 
-platform-tools\fastboot flash boot db_image\boot-linaro-stretch-qcom-snapdragon-arm64-20171016-283.img
-platform-tools\fastboot flash rootfs db_image\linaro-stretch-developer-qcom-snapdragon-arm64-20171016-283_martha.img
+platform-tools\fastboot flash boot db_image\boot-linaro-buster-dragonboard-410c-528.img
+platform-tools\fastboot flash rootfs db_image\martha-linaro-developer-dragonboard-410c.img
 platform-tools\fastboot reboot
 
 GOTO END

--- a/src/flash_db410.sh
+++ b/src/flash_db410.sh
@@ -7,13 +7,13 @@
 DEVICE_ID=$(platform-tools/fastboot devices)
 
 function flashall {
-    platform-tools/fastboot flash partition db_image/gpt_both0.bin
-    platform-tools/fastboot flash hyp db_image/hyp.mbn
-    platform-tools/fastboot flash rpm db_image/rpm.mbn
-    platform-tools/fastboot flash sbl1 db_image/sbl1.mbn
-    platform-tools/fastboot flash tz db_image/tz.mbn
-    platform-tools/fastboot flash aboot db_image/emmc_appsboot.mbn
-    platform-tools/fastboot flash cdt db_image/sbc_1.0_8016.bin
+    platform-tools/fastboot flash partition db_image/*/gpt_both0.bin
+    platform-tools/fastboot flash hyp db_image/*/hyp.mbn
+    platform-tools/fastboot flash rpm db_image/*/rpm.mbn
+    platform-tools/fastboot flash sbl1 db_image/*/sbl1.mbn
+    platform-tools/fastboot flash tz db_image/*/tz.mbn
+    platform-tools/fastboot flash aboot db_image/*/emmc_appsboot.mbn
+    platform-tools/fastboot flash cdt db_image/*/sbc_1.0_8016.bin
 
     platform-tools/fastboot erase boot
     platform-tools/fastboot erase rootfs
@@ -21,8 +21,8 @@ function flashall {
 
     platform-tools/fastboot reboot
 
-    platform-tools/fastboot flash boot db_image/boot-linaro-stretch-qcom-snapdragon-arm64-20171016-283.img
-    platform-tools/fastboot flash rootfs db_image/linaro-stretch-developer-qcom-snapdragon-arm64-20171016-283_martha.img
+    platform-tools/fastboot flash boot db_image/boot-linaro-buster-dragonboard-410c-528.img
+    platform-tools/fastboot flash rootfs db_image/martha-linaro-developer-dragonboard-410c.img
 
     platform-tools/fastboot reboot
 }


### PR DESCRIPTION
Uses the following rootfs image:
http://releases.linaro.org/96boards/dragonboard410c/linaro/debian/latest/linaro-buster-developer-dragonboard-410c-528.img.gz